### PR TITLE
Limit allowed duration values to uint16

### DIFF
--- a/API/DeviceControl/ControlLogic.cs
+++ b/API/DeviceControl/ControlLogic.cs
@@ -112,7 +112,7 @@ public static class ControlLogic
             {
                 Id = shockerInfo.Id,
                 RfId = shockerInfo.RfId,
-                Duration = Math.Clamp(shock.Duration, 300, durationMax),
+                Duration = Math.Clamp(shock.Duration, (ushort)300, durationMax),
                 Intensity = Math.Clamp(shock.Intensity, (byte)1, intensityMax),
                 Type = shock.Type,
                 Model = shockerInfo.Model

--- a/API/DeviceControl/ControlShockerObj.cs
+++ b/API/DeviceControl/ControlShockerObj.cs
@@ -18,7 +18,7 @@ public class ControlShockerObj
         public required bool Sound { get; set; }
         public required bool Vibrate { get; set; }
         public required bool Shock { get; set; }
-        public required uint? Duration { get; set; }
+        public required ushort? Duration { get; set; }
         public required byte? Intensity { get; set; }
     }
     

--- a/API/Models/Response/ShockerLimits.cs
+++ b/API/Models/Response/ShockerLimits.cs
@@ -7,5 +7,5 @@ public class ShockerLimits
     [Range(1, 100)]
     public required byte? Intensity { get; set; }
     [Range(300, 30000)]
-    public required uint? Duration { get; set; }
+    public required ushort? Duration { get; set; }
 }

--- a/Common/Models/WebSocket/User/Control.cs
+++ b/Common/Models/WebSocket/User/Control.cs
@@ -11,5 +11,5 @@ public class Control
     [Range(1, 100)]
     public required byte Intensity { get; set; }
     [Range(300, 30000)]
-    public required uint Duration { get; set; }
+    public required ushort Duration { get; set; }
 }

--- a/Common/OpenShockDb/ShockerShare.cs
+++ b/Common/OpenShockDb/ShockerShare.cs
@@ -17,7 +17,7 @@ public partial class ShockerShare
 
     public bool? PermShock { get; set; }
 
-    public uint? LimitDuration { get; set; }
+    public ushort? LimitDuration { get; set; }
 
     public byte? LimitIntensity { get; set; }
 

--- a/Common/OpenShockDb/ShockerShareCode.cs
+++ b/Common/OpenShockDb/ShockerShareCode.cs
@@ -17,7 +17,7 @@ public partial class ShockerShareCode
 
     public bool? PermShock { get; set; }
 
-    public uint? LimitDuration { get; set; }
+    public ushort? LimitDuration { get; set; }
 
     public byte? LimitIntensity { get; set; }
 

--- a/Common/OpenShockDb/ShockerSharesLinksShocker.cs
+++ b/Common/OpenShockDb/ShockerSharesLinksShocker.cs
@@ -15,7 +15,7 @@ public partial class ShockerSharesLinksShocker
 
     public bool PermShock { get; set; }
 
-    public uint? LimitDuration { get; set; }
+    public ushort? LimitDuration { get; set; }
 
     public byte? LimitIntensity { get; set; }
 

--- a/Common/Redis/PubSub/ControlMessage.cs
+++ b/Common/Redis/PubSub/ControlMessage.cs
@@ -14,7 +14,7 @@ public class ControlMessage
         public required Guid Id { get; set; }
         public required ushort RfId { get; set; }
         public required byte Intensity { get; set; }
-        public required uint Duration { get; set; }
+        public required ushort Duration { get; set; }
         public required ControlType Type { get; set; }
         public required ShockerModelType Model { get; set; }
     }

--- a/LiveControlGateway/Serialization/ServerToDeviceMessage.fbs
+++ b/LiveControlGateway/Serialization/ServerToDeviceMessage.fbs
@@ -10,7 +10,7 @@ struct ShockerCommand {
   id:uint16;
   type:Types.ShockerCommandType;
   intensity:uint8;
-  duration:uint32;
+  duration:uint16;
 }
 
 table ShockerCommandList {


### PR DESCRIPTION
This simplifies the logic everywhere because no command should ever exceed a uint16 value.

Uint16 has a max value of 65535, which when counting milliseconds amounts to a little more than a minute of constant command. 

This should be the upper limit if this ever for some reason gets corrupted or underflows.

Unsure about modifying the DB models here, but @LucHeart should know if this is ok or not, feel free to revert the db model changes.