### PR TITLE
Added Helm chart

### DIFF
--- a/charts/openshock/.helmignore
+++ b/charts/openshock/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/openshock/Chart.yaml
+++ b/charts/openshock/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openshock
+description: A Helm chart for the OpenShock.
+type: application
+version: 0.1.0
+appVersion: "3.2.0"

--- a/charts/openshock/templates/NOTES.txt
+++ b/charts/openshock/templates/NOTES.txt
@@ -1,0 +1,26 @@
+{{- range $name, $values := dict "api" .Values.api "cron" .Values.cron "lcg" .Values.liveControllerGateway "webui" .Values.webUi }}
+{{- if $values.enabled }}
+Get the {{ $name }} URL by running these commands:
+{{- if $values.ingress.enabled }}
+{{- range $host := $values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" $values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openshock.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" $values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "openshock.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openshock.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ $values.service.port }}
+{{- else if contains "ClusterIP" $values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "openshock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openshock/templates/_helpers.tpl
+++ b/charts/openshock/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openshock.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openshock.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openshock.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openshock.labels" -}}
+helm.sh/chart: {{ include "openshock.chart" . }}
+{{ include "openshock.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openshock.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openshock.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/openshock/templates/configmap-webui.yaml
+++ b/charts/openshock/templates/configmap-webui.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.webUi.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ include "openshock.fullname" $ }}-webui'
+  labels:
+    {{- include "openshock.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webui
+data:
+  startup.sh: |
+    #!/bin/sh
+    cp -r /usr/share/nginx/html/. /html
+    inject() {
+      echo "Injecting variable: $1 = $2"
+      find /html -name "*.js" -exec sed -i "s|$1|$2|g" {} +
+      find /html -name "*.html" -exec sed -i "s|$1|$2|g" {} +
+    }
+    inject OPENSHOCK_NAME {{ .Values.appConfig.frontend.name }}
+    inject OPENSHOCK_URL {{ .Values.appConfig.frontend.baseUrl }}
+    inject OPENSHOCK_API_URL {{ .Values.appConfig.apiUrl }}
+    inject OPENSHOCK_SHARE_URL {{ .Values.appConfig.frontend.shortUrl }}
+  nginx.conf: |
+    worker_processes  auto;
+
+    error_log  /tmp/nginx/error.log warn;
+    pid        /tmp/nginx/nginx.pid;
+
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        include /etc/nginx/conf.d/*.conf;
+    }
+  default.conf: |
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+{{- end }}

--- a/charts/openshock/templates/deployment-webui.yaml
+++ b/charts/openshock/templates/deployment-webui.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.webUi.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ include "openshock.fullname" . }}-webui'
+  labels:
+    {{- include "openshock.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webui
+spec:
+  replicas: {{ .Values.webUi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openshock.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: webui
+  template:
+    metadata:
+      {{- with .Values.webUi.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "openshock.labels" $ | nindent 8 }}
+        {{- with .Values.webUi.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/component: webui
+    spec:
+      {{- with .Values.webUi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.webUi.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: false
+      initContainers:
+        - name: init-html
+          securityContext:
+            {{- toYaml .Values.webUi.securityContext | nindent 12 }}
+          image: "{{ .Values.webUi.image.repository }}:{{ .Values.webUi.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.webUi.image.pullPolicy }}
+          command: ["/startup.sh"]
+          volumeMounts:
+            - name: config
+              mountPath: "/startup.sh"
+              subPath: startup.sh
+            - name: html
+              mountPath: "/html"
+              readOnly: false
+      containers:
+        - name: webui
+          securityContext:
+            {{- toYaml .Values.webUi.securityContext | nindent 12 }}
+          image: "{{ .Values.webUi.image.repository }}:{{ .Values.webUi.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.webUi.image.pullPolicy }}
+          command: ["./docker-entrypoint.sh", "nginx", "-g", "daemon off;"] # bipass startup script that edits files. Using init container instead.
+          ports:
+            - name: http
+              containerPort: {{ .Values.webUi.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.webUi.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.webUi.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.webUi.resources | nindent 12 }}
+          volumeMounts:
+            - name: html
+              mountPath: "/usr/share/nginx/html"
+              readOnly: true
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: tmp
+              mountPath: /tmp/nginx
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: config
+          configMap:
+            name: '{{ include "openshock.fullname" $ }}-webui'
+            items:
+              - key: startup.sh
+                path: startup.sh
+                mode: 0555
+              - key: nginx.conf
+                path: nginx.conf
+              - key: default.conf
+                path: default.conf
+        - name: html
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {} 
+      {{- with .Values.webUi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webUi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webUi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/openshock/templates/deployments-backend.yaml
+++ b/charts/openshock/templates/deployments-backend.yaml
@@ -1,0 +1,203 @@
+{{- range $name, $values := dict "api" .Values.api "cron" .Values.cron "lcg" .Values.liveControllerGateway -}}
+{{- if $values.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ include "openshock.fullname" $ }}-{{ $name }}'
+  labels:
+    {{- include "openshock.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+spec:
+  {{ if eq $name "api" }}replicas: {{ $values.replicaCount }}
+  {{ else if eq $name "cron" }}replicas: 1 # Can scale but theres no point because short outages don't matter.
+  {{ else if eq $name "lcg" }}replicas: 1 # Can't scale.
+  {{ else if eq $name "webui" }}replicas: {{ $values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openshock.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $name }}
+  template:
+    metadata:
+      {{- with $values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "openshock.labels" $ | nindent 8 }}
+        {{- with $values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/component: {{ $name }}
+    spec:
+      {{- with $values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ $name }}
+          securityContext:
+            {{- toYaml $values.securityContext | nindent 12 }}
+          image: "{{ $values.image.repository }}:{{ $values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $values.image.pullPolicy }}
+          {{ if eq $name "webui" }}command: ["./docker-entrypoint.sh", "nginx", "-g", "daemon off;"]{{ end }}  # bipass startup script that edits files. Using init container instead.
+          env:
+            {{- if eq $name "api" }}  # --- API
+              - name: OPENSHOCK__DB__CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.database.connectionSecretName }}
+                    key: {{ $.Values.appConfig.database.connectionSecretKey }}
+              - name: OPENSHOCK__DB__SKIPMIGRATION
+                value: "{{ $.Values.appConfig.database.skipmigration }}"
+              - name: OPENSHOCK__DB__DEBUG
+                value: "{{ $.Values.appConfig.database.debug }}"
+              - name: OPENSHOCK__REDIS__HOST
+                value: {{ $.Values.appConfig.redis.host }}
+              - name: OPENSHOCK__REDIS__PORT
+                value: "{{ $.Values.appConfig.redis.port }}"
+              - name: OPENSHOCK__REDIS__USER
+                value: {{ $.Values.appConfig.redis.user }}
+              {{- if $.Values.appConfig.redis.passwordSecretName }}
+              - name: OPENSHOCK__REDIS__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.redis.passwordSecretName }}
+                    key: {{ $.Values.appConfig.redis.passwordSecretKey }}
+              {{- end }}
+              - name: OPENSHOCK__FRONTEND__BASEURL
+                value: {{ $.Values.appConfig.frontend.baseUrl }}
+              - name: OPENSHOCK__FRONTEND__SHORTURL
+                value: {{ $.Values.appConfig.frontend.shortUrl }}
+              - name: OPENSHOCK__FRONTEND__COOKIEDOMAIN
+                value: {{ $.Values.appConfig.frontend.cookieDomain }}
+              - name: OPENSHOCK__MAIL__SENDER__EMAIL
+                value: {{ $.Values.appConfig.mail.senderEmail }}
+              - name: OPENSHOCK__MAIL__SENDER__NAME
+                value: {{ $.Values.appConfig.mail.senderName }}
+              - name: OPENSHOCK__MAIL__TYPE
+                value: {{ $.Values.appConfig.mail.type }}
+              {{- if eq (upper $.Values.appConfig.mail.type) "MAILJET" }}
+              - name: OPENSHOCK__MAIL__MAILJET__KEY
+                value: {{ $.Values.appConfig.mail.mailjet.key }}
+              - name: OPENSHOCK__MAIL__MAILJET__SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.mail.mailjet.secretSecretName }}
+                    key: {{ $.Values.appConfig.mail.mailjet.secretSecretKey }}
+              - name: OPENSHOCK__MAIL__MAILJET__TEMPLATE__PASSWORDRESET
+                value: "{{ $.Values.appConfig.mail.mailjet.templatePasswordRest }}"
+              {{- end }}
+              {{- if eq (upper $.Values.appConfig.mail.type) "SMTP" }}
+              - name: OPENSHOCK__MAIL__SMTP__HOST
+                value: {{ $.Values.appConfig.mail.smtp.host }}
+              - name: OPENSHOCK__MAIL__SMTP__USERNAME
+                value: {{ $.Values.appConfig.mail.smtp.username }}
+              - name: OPENSHOCK__MAIL__SMTP__ENABLESSL
+                value: "{{ $.Values.appConfig.mail.smtp.enableSsl }}"
+              - name: OPENSHOCK__MAIL__SMTP__VERIFYCERTIFICATE
+                value: "{{ $.Values.appConfig.mail.smtp.verifyCertificate }}"
+              - name: OPENSHOCK__MAIL__SMTP__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.mail.smtp.passwordSecretName }}
+                    key: {{ $.Values.appConfig.mail.smtp.passwordSecretKey }}
+              {{- end }}
+              - name: OPENSHOCK__TURNSTILE__ENABLE
+                value: "{{ $.Values.appConfig.turnstile.enabled }}"
+              {{- if eq (lower $.Values.appConfig.turnstile.enabled) "true" }}
+              - name: OPENSHOCK__TURNSTILE__SITEKEY
+                value: {{ $.Values.appConfig.turnstile.siteKey }}
+              - name: OPENSHOCK__TURNSTILE__SECRETKEY
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.mail.turnstile.secretKeySecretName }}
+                    key: {{ $.Values.appConfig.mail.turnstile.secretKeySecretKey }}
+              {{- end }}
+            {{- else if eq $name "cron" }} # --- Cron
+              - name: OPENSHOCK__DB__CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.database.connectionSecretName }}
+                    key: {{ $.Values.appConfig.database.connectionSecretKey }}
+              - name: OPENSHOCK__DB__SKIPMIGRATION
+                value: "{{ $.Values.appConfig.database.skipmigration }}"
+              - name: OPENSHOCK__DB__DEBUG
+                value: "{{ $.Values.appConfig.database.debug }}"
+              - name: OPENSHOCK__REDIS__HOST
+                value: {{ $.Values.appConfig.redis.host }}
+              - name: OPENSHOCK__REDIS__PORT
+                value: "{{ $.Values.appConfig.redis.port }}"
+              - name: OPENSHOCK__REDIS__USER
+                value: {{ $.Values.appConfig.redis.user }}
+              {{- if $.Values.appConfig.redis.passwordSecretName }}
+              - name: OPENSHOCK__REDIS__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.redis.passwordSecretName }}
+                    key: {{ $.Values.appConfig.redis.passwordSecretKey }}
+              {{- end }}
+            {{- else if eq $name "lcg" }} # --- Live Controller Gateway
+              - name: OPENSHOCK__DB__CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.database.connectionSecretName }}
+                    key: {{ $.Values.appConfig.database.connectionSecretKey }}
+              - name: OPENSHOCK__DB__SKIPMIGRATION
+                value: "{{ $.Values.appConfig.database.skipmigration }}"
+              - name: OPENSHOCK__DB__DEBUG
+                value: "{{ $.Values.appConfig.database.debug }}"
+              - name: OPENSHOCK__REDIS__HOST
+                value: {{ $.Values.appConfig.redis.host }}
+              - name: OPENSHOCK__REDIS__PORT
+                value: "{{ $.Values.appConfig.redis.port }}"
+              - name: OPENSHOCK__REDIS__USER
+                value: {{ $.Values.appConfig.redis.user }}
+              {{- if $.Values.appConfig.redis.passwordSecretName }}
+              - name: OPENSHOCK__REDIS__PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $.Values.appConfig.redis.passwordSecretName }}
+                    key: {{ $.Values.appConfig.redis.passwordSecretKey }}
+              {{- end }}
+              - name: OPENSHOCK__LCG__COUNTRYCODE
+                value: "{{ $.Values.appConfig.liveControllerGateway.countryCode }}"
+              - name: OPENSHOCK__LCG__FQDN
+                value: "{{ $.Values.appConfig.liveControllerGateway.fcdn }}"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml $values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $values.resources | nindent 12 }}
+          {{- with $values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with $values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/charts/openshock/templates/ingresses.yaml
+++ b/charts/openshock/templates/ingresses.yaml
@@ -1,0 +1,47 @@
+{{- range $name, $values := dict "api" .Values.api "cron" .Values.cron "lcg" .Values.liveControllerGateway "webui" .Values.webUi -}}
+{{- if and $values.ingress.enabled $values.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: '{{ include "openshock.fullname" $ }}-{{ $name }}'
+  labels:
+    {{- include "openshock.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+  {{- with $values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if $values.ingress.tls }}
+  tls:
+    {{- range $values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "openshock.fullname" $ }}-{{ $name }}
+                port:
+                  number: {{ $values.service.port }}
+          {{- end }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/charts/openshock/templates/services.yaml
+++ b/charts/openshock/templates/services.yaml
@@ -1,0 +1,22 @@
+{{- range $name, $values := dict "api" .Values.api "cron" .Values.cron "lcg" .Values.liveControllerGateway "webui" .Values.webUi -}}
+{{- if $values.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: '{{ include "openshock.fullname" $ }}-{{ $name }}'
+  labels:
+    {{- include "openshock.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+spec:
+  type: {{ $values.service.type }}
+  ports:
+    - port: {{ $values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openshock.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+---
+{{- end }}
+{{- end }}

--- a/charts/openshock/templates/tests/test-connection.yaml
+++ b/charts/openshock/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "openshock.fullname" . }}-api-test-connection"
+  labels:
+    {{- include "openshock.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "openshock.fullname" . }}-api:{{ .Values.api.service.port }}']
+  restartPolicy: Never

--- a/charts/openshock/values.yaml
+++ b/charts/openshock/values.yaml
@@ -1,0 +1,256 @@
+# Open shock is made up of 4 apps. The API, Gateway, WebUI and Cron. 
+# Each of them is configured in their own section here.
+
+# The WebUI is a static web app. Its likely best to host it elsewhere. E.g. Github pages. 
+# But I've added it here anyway for your convenience. However its disabled by default.
+
+
+# Any appConfig that ends in "SecretName" wants the name of a Kubernetes opaque secret. "SecretKey" is the name of the key in this Kubernetes secret.
+appConfig:
+  database:
+    connectionSecretName: # Required. Secret containing postgresql database connection string
+    connectionSecretKey: # Required
+    skipmigration: "false"
+    debug: "false"
+  redis:
+    host: # Required
+    port: "6379"
+    user:
+    passwordSecretName:
+    passwordSecretKey:
+  frontend:
+    name: Openshock # Name of the OpenShock instance.
+    baseUrl:  # Required. URL of the OpenShock WebUI. (NO trailing slash!)
+    shortUrl: # Required. URL to prefix share links with. (NO trailing slash!). Can be the same as frontendBaseUrl
+    cookieDomain: # Required
+  apiUrl: # Required
+  mail:
+    senderEmail: # Required
+    senderName: # Required
+    type: MAILJET # MAILJET or SMTP, check Documentation
+    mailjet: # All of the following is required of mailType is MAILJET
+      key: 
+      secretSecretName: # Name of the Kubernetes Secret containing the Mailjet secret
+      secretSecretKey: # Key of the Kubernetes Secret
+      templatePasswordRest:
+    smtp: # All of the following is required of mailType is SMTP
+      host:
+      username:
+      passwordSecretName: 
+      passwordSecretKey: 
+      enableSsl: "true"
+      verifyCertificate: "true"
+  liveControllerGateway:
+    fqdn: # Required
+    countryCodes: # Required
+  turnstile:
+    enabled: "false" # All the other turnstile values are required if this is true
+    sitekey: # Required if enabled is true
+    secretKeySecretName: 
+    secretKeySecretKey: 
+
+api:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/openshock/api
+    pullPolicy: IfNotPresent
+    tag: ""
+  
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+  podAnnotations: {}
+  podLabels: {}
+  podSelectorLabels: 
+
+  podSecurityContext: 
+    fsGroup: 2000
+    sysctls: # API listens on port 80 and there is no way to configure that
+      - name: net.ipv4.ip_unprivileged_port_start
+        value: "79"
+  securityContext: 
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+  service:
+    type: ClusterIP
+    port: 80
+  
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  
+  resources: {}
+  livenessProbe:
+    httpGet:
+      path: /1/
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /1/
+      port: http
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+
+cron:
+  enabled: true
+
+  image:
+    repository: ghcr.io/openshock/cron
+    pullPolicy: IfNotPresent
+    tag: ""
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: 
+    fsGroup: 2000
+    sysctls:  # Cron listens on port 730 and there is no way to configure that
+      - name: net.ipv4.ip_unprivileged_port_start
+        value: "729"
+  securityContext: 
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+  service:
+    type: ClusterIP
+    port: 780
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  resources: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+
+liveControllerGateway:
+  enabled: true
+
+  image:
+    repository: ghcr.io/openshock/live-control-gateway
+    pullPolicy: IfNotPresent
+    tag: ""
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: 
+    fsGroup: 2000
+    sysctls:
+      - name: net.ipv4.ip_unprivileged_port_start
+        value: "79"
+  securityContext: 
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:  # Only used for a Hangfire Dashboard
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  resources: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+
+webUi:
+  enabled: false
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/openshock/webui
+    pullPolicy: IfNotPresent
+    tag: latest # Uses different versioning from the rest of the APIs
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: 
+    fsGroup: 2000
+  securityContext: 
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  resources: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
Helm is a convenient way to package up and template a lot of Kubernetes manifest files. It makes it easier for end users to deploy a production ready OpenShock instance of their own. This is important for people like me and my friends who live on the other side of the world from the official servers where latency is bad. It also makes OpenShock more open.

I've created a Helm chart to deploy the OpenShock API, Cron, LCG and the WebUI. 

Everything should comply with a lot of Kubernetes security standards by default. E.g. Everything has read only files systems and doesn't run as root.

The Web UI is likely best not hosted in Kubernetes but I've added it here anyway for peoples convenance. To meet the above security standards, I had to replace the WebUI startup script with my own modified script in an Init Container. I also had to make some configuration changes to Nginx. This new script and config can be seen in the ConfigMap. 

Testing:
Currently I'm running this on my home servers for a small number of my friends. I haven't ran into any issues yet. I don't want to make the URL public but if you'd like to test it, please message me on Discord for access.

Current PR status:
Changes are still under test and I'd like feedback on my work. To indicate this status, the version of the Helm chart is "0.1.0"
I also need to improve documentation. I'll likely add a guide on how to host in an MD file somewhere.