### PR TITLE
Show multiple versions in scalar viewer in a quirky manner

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -97,7 +97,14 @@ app.MapControllers();
 app.MapHub<UserHub>("/1/hubs/user", options => options.Transports = HttpTransportType.WebSockets);
 app.MapHub<ShareLinkHub>("/1/hubs/share/link/{id:guid}", options => options.Transports = HttpTransportType.WebSockets);
 
-app.MapScalarApiReference(options => options.OpenApiRoutePattern = "/swagger/{documentName}/swagger.json");
+Action<ScalarOptions> scalarOptions = options =>
+    options
+        .WithOpenApiRoutePattern("/swagger/{documentName}/swagger.json")
+        .AddDocument("1", "Version 1")
+        .AddDocument("2", "Version 2");
+app.MapScalarApiReference("/scalar/viewer", scalarOptions);
+// Routing for /scalar, E.g: /scalar/1 and /scalar/2
+app.MapScalarApiReference(scalarOptions);
 
 app.Run();
 


### PR DESCRIPTION
So for whatever reason, the routing really doesn't like the idea of routing to a single field, like /favicon.ico or /scalar
To work around this, I propose we add some additional routing so that we can access the API documentation at /scalar/viewer so that users can go there and then choose which version of the API they wish to view


Screenshot of what I'm talking about:
![image](https://github.com/user-attachments/assets/0c9ff432-7ccb-4813-903b-35763539aa0c)
