### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Preferred way is a .env file.
 | `OPENSHOCK__LCG__FQDN`              | x        |               | `de1-gateway.my-openshock-instance.net` `de1-gateway.shocklink.net`                                      |
 | `OPENSHOCK__LCG__COUNTRYCODE`       | x        |               | `DE`                                                                                                     |
 
-Reffer to the [Npgsql Connection String](https://www.npgsql.org/doc/connection-string-parameters.html) documentation page for details about `OPENSHOCK__DB_CONN`.  
-Reffer to [StackExchange.Redis Configuration](https://stackexchange.github.io/StackExchange.Redis/Configuration.html) documention page for details about `OPENSHOCK__REDIS__CONN`.
+Refer to the [Npgsql Connection String](https://www.npgsql.org/doc/connection-string-parameters.html) documentation page for details about `OPENSHOCK__DB_CONN`.
+Refer to [StackExchange.Redis Configuration](https://stackexchange.github.io/StackExchange.Redis/Configuration.html) documentation page for details about `OPENSHOCK__REDIS__CONN`.
 
 ## Turnstile
 


### PR DESCRIPTION
## Summary
- correct typos in instructions to refer to documentation

## Testing
- `dotnet test Common.Tests/Common.Tests.csproj --verbosity minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b41bffd1c83289afbcd1b1f5d4084