### PR TITLE
Verify user exists after signup

### DIFF
--- a/API.IntegrationTests/AccountTests.cs
+++ b/API.IntegrationTests/AccountTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Net;
 using System.Text;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OpenShock.Common.OpenShockDb;
 
 namespace OpenShock.API.IntegrationTests;
 
@@ -25,5 +28,12 @@ public class AccountTests : BaseIntegrationTest
         var content = await response.Content.ReadAsStringAsync();
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        await using var scope = WebAppFactory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Email == "bob@example.com");
+
+        await Assert.That(user is not null).IsTrue();
     }
 }


### PR DESCRIPTION
## Summary
- enhance `CreateAccount_ShouldAdd_NewUserToDatabase` test
- query `OpenShockContext` after signup and assert the user exists

## Testing
- `dotnet test API.IntegrationTests/API.IntegrationTests.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b421e15788328ba89687bed9a2533