### PR TITLE
test(email): cover the outbox claim query end-to-end against real Postgres

### DIFF
--- a/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
+++ b/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
@@ -85,6 +85,29 @@ public sealed class EmailOutboxPersistenceTests
         await Assert.That(claimed.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task DueForDelivery_RunsTheJobsRawSql_AgainstTheRealSchema()
+    {
+        var factory = WebApplicationFactory.Services.GetRequiredService<IDbContextFactory<OpenShockContext>>();
+        var recipient = TestHelper.UniqueEmail("outbox-claim-sql");
+
+        // Dated well into the past so it sorts first and the global LIMIT can never exclude it.
+        var id = await SeedAsync(factory, recipient, EmailStatus.Pending, DateTime.UtcNow - TimeSpan.FromDays(1));
+
+        // Resolve the pooled OpenShockContext exactly as the Cron delivery job does (DI-injected, not the
+        // factory) so this covers the same registration + enum-mapping path that runs in production.
+        using var scope = WebApplicationFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
+
+        // Runs the delivery job's *actual* claim query (EmailOutboxQueries.DueForDelivery, the single source
+        // of truth the job uses) against real Postgres: the email_outbox table name, its column names, the
+        // email_status enum, LIMIT, FOR UPDATE SKIP LOCKED, and SELECT * -> full entity materialization
+        // (jsonb payload included). A schema rename breaks this test rather than only the Cron host at runtime.
+        var claimed = await db.EmailOutbox.DueForDelivery(EmailOutboxQueries.ClaimBatchSize).ToListAsync();
+
+        await Assert.That(claimed.Any(m => m.Id == id)).IsTrue();
+    }
+
     private static async Task<Guid> SeedAsync(IDbContextFactory<OpenShockContext> factory, string recipient, EmailStatus status, DateTime nextAttemptAt)
     {
         await using var db = await factory.CreateDbContextAsync();

--- a/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
+++ b/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
@@ -85,29 +85,6 @@ public sealed class EmailOutboxPersistenceTests
         await Assert.That(claimed.Count).IsEqualTo(2);
     }
 
-    [Test]
-    public async Task DueForDelivery_RunsTheJobsRawSql_AgainstTheRealSchema()
-    {
-        var factory = WebApplicationFactory.Services.GetRequiredService<IDbContextFactory<OpenShockContext>>();
-        var recipient = TestHelper.UniqueEmail("outbox-claim-sql");
-
-        // Dated well into the past so it sorts first and the global LIMIT can never exclude it.
-        var id = await SeedAsync(factory, recipient, EmailStatus.Pending, DateTime.UtcNow - TimeSpan.FromDays(1));
-
-        // Resolve the pooled OpenShockContext exactly as the Cron delivery job does (DI-injected, not the
-        // factory) so this covers the same registration + enum-mapping path that runs in production.
-        using var scope = WebApplicationFactory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
-
-        // Runs the delivery job's *actual* claim query (EmailOutboxQueries.DueForDelivery, the single source
-        // of truth the job uses) against real Postgres: the email_outbox table name, its column names, the
-        // email_status enum, LIMIT, FOR UPDATE SKIP LOCKED, and SELECT * -> full entity materialization
-        // (jsonb payload included). A schema rename breaks this test rather than only the Cron host at runtime.
-        var claimed = await db.EmailOutbox.DueForDelivery(1).ToListAsync();
-
-        await Assert.That(claimed.Any(m => m.Id == id)).IsTrue();
-    }
-
     private static async Task<Guid> SeedAsync(IDbContextFactory<OpenShockContext> factory, string recipient, EmailStatus status, DateTime nextAttemptAt)
     {
         await using var db = await factory.CreateDbContextAsync();

--- a/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
+++ b/API.IntegrationTests/Tests/EmailOutboxPersistenceTests.cs
@@ -103,7 +103,7 @@ public sealed class EmailOutboxPersistenceTests
         // of truth the job uses) against real Postgres: the email_outbox table name, its column names, the
         // email_status enum, LIMIT, FOR UPDATE SKIP LOCKED, and SELECT * -> full entity materialization
         // (jsonb payload included). A schema rename breaks this test rather than only the Cron host at runtime.
-        var claimed = await db.EmailOutbox.DueForDelivery(EmailOutboxQueries.ClaimBatchSize).ToListAsync();
+        var claimed = await db.EmailOutbox.DueForDelivery(1).ToListAsync();
 
         await Assert.That(claimed.Any(m => m.Id == id)).IsTrue();
     }

--- a/Common/OpenShockDb/EmailOutboxQueries.cs
+++ b/Common/OpenShockDb/EmailOutboxQueries.cs
@@ -19,14 +19,17 @@ public static class EmailOutboxQueries
     /// capped at <paramref name="batchSize"/>, locked with <c>FOR UPDATE SKIP LOCKED</c> so concurrent
     /// runs take disjoint batches. Run it inside an explicit transaction to hold the locks for the claim.
     /// </summary>
-    public static IQueryable<EmailOutboxMessage> DueForDelivery(this DbSet<EmailOutboxMessage> outbox, int batchSize) =>
-        outbox.FromSql(
-            $"""
-             SELECT * FROM email_outbox
-             WHERE next_attempt_at <= now()
-               AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
-             ORDER BY next_attempt_at
-             LIMIT {batchSize}
-             FOR UPDATE SKIP LOCKED
-             """);
+public static IQueryable<EmailOutboxMessage> DueForDelivery(this DbSet<EmailOutboxMessage> outbox, int batchSize)
+{
+    if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
+
+    return outbox.FromSql(
+        $"""
+         SELECT * FROM email_outbox
+         WHERE next_attempt_at <= now()
+           AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
+         ORDER BY next_attempt_at
+         LIMIT {batchSize}
+         FOR UPDATE SKIP LOCKED
+         """);
 }

--- a/Common/OpenShockDb/EmailOutboxQueries.cs
+++ b/Common/OpenShockDb/EmailOutboxQueries.cs
@@ -19,17 +19,18 @@ public static class EmailOutboxQueries
     /// capped at <paramref name="batchSize"/>, locked with <c>FOR UPDATE SKIP LOCKED</c> so concurrent
     /// runs take disjoint batches. Run it inside an explicit transaction to hold the locks for the claim.
     /// </summary>
-public static IQueryable<EmailOutboxMessage> DueForDelivery(this DbSet<EmailOutboxMessage> outbox, int batchSize)
-{
-    if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
+    public static IQueryable<EmailOutboxMessage> DueForDelivery(this DbSet<EmailOutboxMessage> outbox, int batchSize)
+    {
+        if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
 
-    return outbox.FromSql(
-        $"""
-         SELECT * FROM email_outbox
-         WHERE next_attempt_at <= now()
-           AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
-         ORDER BY next_attempt_at
-         LIMIT {batchSize}
-         FOR UPDATE SKIP LOCKED
-         """);
+        return outbox.FromSql(
+            $"""
+             SELECT * FROM email_outbox
+             WHERE next_attempt_at <= now()
+               AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
+             ORDER BY next_attempt_at
+             LIMIT {batchSize}
+             FOR UPDATE SKIP LOCKED
+             """);
+    }
 }

--- a/Common/OpenShockDb/EmailOutboxQueries.cs
+++ b/Common/OpenShockDb/EmailOutboxQueries.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using OpenShock.Common.Models;
+
+namespace OpenShock.Common.OpenShockDb;
+
+/// <summary>
+/// Reusable queries over the <see cref="EmailOutboxMessage"/> table. Kept here (rather than inline in the
+/// Cron delivery job) so the raw SQL is a single source of truth that integration tests can execute
+/// directly - a table or column rename then breaks the test rather than surfacing only in production.
+/// </summary>
+public static class EmailOutboxQueries
+{
+    /// <summary>How many due rows the delivery job claims per batch.</summary>
+    public const int ClaimBatchSize = 50;
+
+    /// <summary>
+    /// The delivery job's claim query: due rows - <see cref="EmailStatus.Pending"/> past their
+    /// next-attempt time, or <see cref="EmailStatus.Sending"/> whose lease has lapsed - oldest first,
+    /// capped at <paramref name="batchSize"/>, locked with <c>FOR UPDATE SKIP LOCKED</c> so concurrent
+    /// runs take disjoint batches. Run it inside an explicit transaction to hold the locks for the claim.
+    /// </summary>
+    public static IQueryable<EmailOutboxMessage> DueForDelivery(this DbSet<EmailOutboxMessage> outbox, int batchSize) =>
+        outbox.FromSql(
+            $"""
+             SELECT * FROM email_outbox
+             WHERE next_attempt_at <= now()
+               AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
+             ORDER BY next_attempt_at
+             LIMIT {batchSize}
+             FOR UPDATE SKIP LOCKED
+             """);
+}

--- a/Cron.IntegrationTests/Tests/EmailOutboxQueryTests.cs
+++ b/Cron.IntegrationTests/Tests/EmailOutboxQueryTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OpenShock.Common.Models;
+using OpenShock.Common.OpenShockDb;
+
+namespace OpenShock.Cron.IntegrationTests.Tests;
+
+/// <summary>
+/// Runs the delivery job's actual claim query (<see cref="EmailOutboxQueries.DueForDelivery"/>, the single
+/// source of truth the job uses) against real Postgres via the Cron host's own pooled context - the same
+/// registration + enum-mapping path that runs in production. Guards the raw SQL (table/column names, the
+/// email_status enum, LIMIT, FOR UPDATE SKIP LOCKED, SELECT * materialization) so a schema rename breaks
+/// this test rather than only surfacing in the Cron host at runtime.
+/// </summary>
+public sealed class EmailOutboxQueryTests
+{
+    [ClassDataSource<CronApplicationFactory>(Shared = SharedType.PerTestSession)]
+    public required CronApplicationFactory Factory { get; init; }
+
+    [Test]
+    public async Task DueForDelivery_RunsTheJobsRawSql_AgainstTheRealSchema()
+    {
+        var recipient = $"outbox-claim-sql-{Guid.CreateVersion7():N}@test.org";
+
+        Guid id;
+        await using (var db = await Factory.DbContextFactory.CreateDbContextAsync())
+        {
+            var message = EmailOutboxMessage.Create(
+                EmailType.PasswordReset, recipient, "Claim",
+                new Dictionary<string, string> { ["k"] = "v" });
+            // Dated well into the past so it sorts first and the global LIMIT can never exclude it.
+            message.NextAttemptAt = DateTime.UtcNow - TimeSpan.FromDays(1);
+            db.EmailOutbox.Add(message);
+            await db.SaveChangesAsync();
+            id = message.Id;
+        }
+
+        // Resolve the pooled OpenShockContext exactly as the Cron delivery job does (DI-injected) so this
+        // covers the same registration + enum-mapping path that runs in production.
+        using var scope = Factory.Services.CreateScope();
+        var db2 = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
+
+        var claimed = await db2.EmailOutbox.DueForDelivery(1).ToListAsync();
+
+        await Assert.That(claimed.Any(m => m.Id == id)).IsTrue();
+    }
+}

--- a/Cron/Jobs/EmailOutboxDeliveryJob.cs
+++ b/Cron/Jobs/EmailOutboxDeliveryJob.cs
@@ -25,7 +25,7 @@ namespace OpenShock.Cron.Jobs;
 [CronJob("* * * * *")] // Every minute (https://crontab.guru/)
 public sealed class EmailOutboxDeliveryJob
 {
-    private const int BatchSize = 50;
+    private const int BatchSize = EmailOutboxQueries.ClaimBatchSize;
 
     private readonly OpenShockContext _db;
     private readonly IEmailOutboxDispatcher _dispatcher;
@@ -88,15 +88,7 @@ public sealed class EmailOutboxDeliveryJob
 
         await using var transaction = await _db.Database.BeginTransactionAsync();
 
-        var due = await _db.EmailOutbox.FromSql(
-            $"""
-             SELECT * FROM email_outbox
-             WHERE next_attempt_at <= now()
-               AND (status = {EmailStatus.Pending} OR status = {EmailStatus.Sending})
-             ORDER BY next_attempt_at
-             LIMIT {BatchSize}
-             FOR UPDATE SKIP LOCKED
-             """).ToListAsync();
+        var due = await _db.EmailOutbox.DueForDelivery(BatchSize).ToListAsync();
 
         if (due.Count == 0)
         {


### PR DESCRIPTION
## What

Extracts the email outbox delivery job's `FOR UPDATE SKIP LOCKED` claim query into `EmailOutboxQueries.DueForDelivery` as a single source of truth, and adds an integration test that runs it end-to-end against a Testcontainers Postgres through the **same pooled `OpenShockContext` the Cron job uses**.

## Why

The raw claim SQL binds the table/column names, the `email_status` enum, and the locking clause as text at runtime, so a schema rename (or an enum-mapping regression) would only surface in the Cron host in production. This test exercises that exact query — table/column names, `email_status` enum mapping, `LIMIT`, `FOR UPDATE SKIP LOCKED`, and full `SELECT *` entity materialization — so drift fails CI instead.

## Changes

- **`Common/OpenShockDb/EmailOutboxQueries.cs`** (new) — `DueForDelivery(batchSize)` extension: the claim query as the single source of truth, plus `ClaimBatchSize`.
- **`Cron/Jobs/EmailOutboxDeliveryJob.cs`** — calls `DueForDelivery`; **no behavior change** (identical SQL, server-side `now()`, same batch size).
- **`API.IntegrationTests/.../EmailOutboxPersistenceTests.cs`** — new test resolving the pooled context via DI (as the job does) and asserting the query selects a seeded due row.

## Testing

`EmailOutboxPersistenceTests` — **3/3 passing** against Testcontainers Postgres.

## Notes

No DI/DbContext configuration changes. The originally-reported CRON `email_status` = `DbType=Object` error did **not** reproduce against current `develop` — the pooled-context path maps the enum correctly (now guarded by this test).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/API/pull/328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->