### PR TITLE
fix(cron): gate startup on schema readiness before opening the pooled context

### DIFF
--- a/Common/OpenShockMiddlewareHelper.cs
+++ b/Common/OpenShockMiddlewareHelper.cs
@@ -118,4 +118,59 @@ public static class OpenShockMiddlewareHelper
 
         return app;
     }
+
+    /// <summary>
+    /// Blocks startup until the database schema is up to date (no pending migrations), for hosts that do
+    /// <em>not</em> own migrations (e.g. the Cron worker - the API is the sole migrator). This is not just
+    /// tidiness: <see cref="OpenShockContext"/> binds Postgres enum types (<c>email_status</c>,
+    /// <c>email_type</c>, ...) to CLR enums <em>by name</em>, and Npgsql resolves those names against the
+    /// type catalog it loads on the data source's first connection and caches for the life of the process.
+    /// If that first connection happens before the migrator has created a newly-added enum, every query
+    /// using it fails permanently ("data type name '...' could not be found") until the process restarts.
+    /// Waiting here guarantees the schema - and its enum types - exists before anything opens the pooled
+    /// context, closing the deploy-time race without this host performing any schema writes of its own.
+    /// </summary>
+    public static async Task<IApplicationBuilder> WaitForOpenShockSchemaReady(this IApplicationBuilder app,
+        DatabaseOptions options, TimeSpan? timeout = null)
+    {
+        using var scope = app.ApplicationServices.CreateScope();
+        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("SchemaReadyGate");
+
+        logger.LogInformation("Waiting for database schema to be up to date (migrations owned by another host)...");
+
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromMinutes(5));
+        var delay = TimeSpan.FromSeconds(1);
+        var maxDelay = TimeSpan.FromSeconds(15);
+
+        while (true)
+        {
+            try
+            {
+                await using var migrationContext = new MigrationOpenShockContext(options.Conn, options.Debug, loggerFactory);
+                var pending = (await migrationContext.Database.GetPendingMigrationsAsync()).ToArray();
+                if (pending.Length == 0)
+                {
+                    logger.LogInformation("Database schema is up to date; proceeding with startup");
+                    return app;
+                }
+
+                logger.LogWarning("Schema not ready: {Count} pending migration(s) [{Migrations}] not yet applied by the migrator",
+                    pending.Length, string.Join(", ", pending));
+            }
+            catch (Exception ex)
+            {
+                // Database not reachable yet, or the migrator is mid-run. Keep waiting rather than crash-looping.
+                logger.LogWarning(ex, "Could not determine migration state; will retry");
+            }
+
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException(
+                    "Timed out waiting for the database schema to be brought up to date by the migrator. " +
+                    "Ensure the API host (the sole migrator) is running and reachable.");
+
+            await Task.Delay(delay);
+            delay = TimeSpan.FromSeconds(Math.Min(maxDelay.TotalSeconds, delay.TotalSeconds * 2));
+        }
+    }
 }

--- a/Cron/Program.cs
+++ b/Cron/Program.cs
@@ -44,6 +44,13 @@ var app = builder.Build();
 
 await app.UseCommonOpenShockMiddleware();
 
+// The Cron host does not own migrations (the API is the sole migrator). Its OpenShockContext binds
+// Postgres enum types by name at the pooled data source's first connection and caches them for the
+// process's life, so it must not open that context before a newly-added enum exists - otherwise every
+// claim query fails permanently ("data type name 'email_status' could not be found"). Block until the
+// migrator has applied all pending migrations, which happens before Hangfire or any job runs below.
+await app.WaitForOpenShockSchemaReady(databaseOptions);
+
 var hangfireOptions = new DashboardOptions();
 if (app.Environment.IsProduction() || Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true")
 {


### PR DESCRIPTION
## Problem

The Cron host was failing every `EmailOutboxDeliveryJob` claim query in production with:

```
The data type name 'email_status' could not be found in the types that were loaded by Npgsql.
```

### Root cause

`OpenShockContext` binds the Postgres enum types (`email_status`, `email_type`, …) to CLR enums **by name** via `MapEnum<T>()`. Npgsql resolves those names against the type catalog it loads on the pooled data source's **first connection**, then caches it for the life of the process.

The Cron host does **not** own migrations — the API is the sole migrator (`API/Program.cs` calls `ApplyPendingOpenShockMigrations`; Cron never did). So during the outbox rollout, Cron's data source loaded its type catalog **before** the API had applied the migration that creates those enums. The missing type was cached as absent, and every query using it failed **permanently** until the process was restarted.

This is a deploy-time race that recurs whenever a new enum consumed by Cron is added.

## Fix

- Add `WaitForOpenShockSchemaReady(DatabaseOptions)` in `Common/OpenShockMiddlewareHelper.cs` — polls `GetPendingMigrationsAsync()` with capped backoff and a timeout.
- Call it in `Cron/Program.cs` right after `UseCommonOpenShockMiddleware()`, **before** Hangfire or any job opens the pooled context.

Cron performs **no** schema writes; the API stays the sole migrator. This closes the race window without reintroducing a cross-host migration write-race.

## Notes

- The `AddPooledDbContextFactory` bare `UseNpgsql` in `AddOpenShockDB` is dead config (`TryAdd` means the enum-mapped pool options win), so it was not the cause — left untouched here.
- Compatible with the integration test harness, which migrates the fresh DB before booting the host (gate sees 0 pending → proceeds immediately).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/API/pull/329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->