### PR TITLE
test(cron): cover the control-log retention trim end-to-end against real Postgres

### DIFF
--- a/Common/OpenShockDb/ShockerControlLogQueries.cs
+++ b/Common/OpenShockDb/ShockerControlLogQueries.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace OpenShock.Common.OpenShockDb;
+
+/// <summary>
+/// Reusable commands over the <c>shocker_control_logs</c> table. Kept here (rather than inline in the
+/// Cron cleanup job) so the raw SQL is a single source of truth that integration tests can execute
+/// directly - a table or column rename then breaks the test rather than surfacing only in production.
+/// </summary>
+public static class ShockerControlLogQueries
+{
+    /// <summary>
+    /// Retention trim: per owning user, keeps the newest <paramref name="maxPerUser"/> control logs (by
+    /// <c>created_at</c>) and deletes the rest. Ownership is resolved through
+    /// <c>shocker -&gt; device -&gt; owner</c>, so the cap is per user, not per shocker or device. Runs as a
+    /// single set-based statement (a window function ranks each user's logs newest-first; anything past the
+    /// cap is deleted). Returns the number of rows deleted.
+    /// </summary>
+    public static Task<int> DeleteControlLogsBeyondPerUserLimitAsync(this OpenShockContext db, int maxPerUser,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxPerUser < 0) throw new ArgumentOutOfRangeException(nameof(maxPerUser));
+
+        return db.Database.ExecuteSqlAsync(
+            $"""
+             WITH ranked_logs AS (
+               SELECT
+                 l.id,
+                 ROW_NUMBER() OVER (PARTITION BY d.owner_id ORDER BY l.created_at DESC) AS rn
+               FROM shocker_control_logs l
+               JOIN shockers s ON s.id = l.shocker_id
+               JOIN devices d ON d.id = s.device_id
+             )
+             DELETE FROM shocker_control_logs l
+             USING ranked_logs rl
+             WHERE l.id = rl.id
+               AND rl.rn > {maxPerUser}
+             """, cancellationToken);
+    }
+}

--- a/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
+++ b/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
@@ -9,9 +9,9 @@ namespace OpenShock.Cron.IntegrationTests.Tests;
 /// <summary>
 /// End-to-end coverage for the Cron retention trim against real Postgres. Runs the cleanup job's *actual*
 /// statement (<see cref="ShockerControlLogQueries.DeleteControlLogsBeyondPerUserLimitAsync"/>, the single
-/// source of truth the job uses) over a seeded user -> device -> shocker -> logs graph, so the real table
-/// and column names, the shocker -> device -> owner join, the per-user window function, and the newest-first
-/// ordering are all exercised. A schema rename breaks this test rather than only the Cron host at runtime.
+/// source of truth the job uses) over a seeded graph, so the real table/column names, the
+/// shocker -> device -> owner join, the per-user window function, and newest-first ordering are exercised.
+/// A schema rename breaks this test rather than only the Cron host at runtime.
 /// </summary>
 public sealed class ControlLogRetentionTests
 {
@@ -19,57 +19,55 @@ public sealed class ControlLogRetentionTests
     public required CronApplicationFactory Factory { get; init; }
 
     [Test]
-    public async Task DeleteControlLogsBeyondPerUserLimit_KeepsNewestPerUser_AndDeletesTheRest()
+    public async Task DeleteControlLogsBeyondPerUserLimit_TrimsPerOwner_KeepsNewest_AndSparesOwnersUnderTheLimit()
     {
         const int keep = 10;
-        const int seed = 15; // 5 over the limit
 
-        var userId = Guid.CreateVersion7();
-        var deviceId = Guid.CreateVersion7();
-        var shockerId = Guid.CreateVersion7();
+        // Owner A is over the limit; owner B is under it. A's logs are attributed to two *different*
+        // controller users (each under the limit on its own) and B's logs to B itself - so the trim is only
+        // correct if it partitions by the shocker's OWNER (d.owner_id). If it instead partitioned by the
+        // controller (l.controlled_by_user_id) it would delete nothing (no controller exceeds the limit); if
+        // it dropped PARTITION BY entirely it would rank globally and wrongly delete B's (older) logs too.
+        var ownerA = Guid.CreateVersion7();
+        var ownerB = Guid.CreateVersion7();
+        var controllerC = Guid.CreateVersion7();
+        var controllerD = Guid.CreateVersion7();
 
-        // Seed `seed` logs with strictly increasing timestamps so newest-first ordering is unambiguous.
-        // Track the ids in age order; the newest `keep` should survive, the oldest `seed - keep` should go.
-        var idsOldestToNewest = new List<Guid>(seed);
+        var shockerA = Guid.CreateVersion7();
+        var shockerB = Guid.CreateVersion7();
+
         var baseTime = DateTime.UtcNow - TimeSpan.FromDays(1);
+
+        // A: 15 logs (5 over). Newest 10 survive, oldest 5 go. Split across controllers C (first 8) and D.
+        var aOldestToNewest = new List<Guid>(15);
+        // B: 5 logs, all older than A's - a global (unpartitioned) trim would wrongly delete them.
+        var bIds = new List<Guid>(5);
 
         await using (var db = await Factory.DbContextFactory.CreateDbContextAsync())
         {
-            db.Users.Add(new User
-            {
-                Id = userId,
-                Name = $"logtrim{userId:N}"[..16],
-                Email = $"logtrim-{userId:N}@test.org",
-                SecurityStamp = Guid.CreateVersion7(),
-                CreatedAt = DateTime.UtcNow,
-                ActivatedAt = DateTime.UtcNow
-            });
-            db.Devices.Add(new Device
-            {
-                Id = deviceId, OwnerId = userId, Name = "LogTrimHub",
-                Token = CryptoUtils.RandomAlphaNumericString(256), CreatedAt = DateTime.UtcNow
-            });
-            db.Shockers.Add(new Shocker
-            {
-                Id = shockerId, Name = "LogTrimShocker", RfId = 1234,
-                DeviceId = deviceId, Model = ShockerModelType.CaiXianlin
-            });
+            db.Users.Add(NewUser(ownerA, "own-a"));
+            db.Users.Add(NewUser(ownerB, "own-b"));
+            db.Users.Add(NewUser(controllerC, "ctl-c"));
+            db.Users.Add(NewUser(controllerD, "ctl-d"));
 
-            for (var i = 0; i < seed; i++)
+            AddShocker(db, shockerB, ownerB, rfId: 2000);
+            AddShocker(db, shockerA, ownerA, rfId: 1000);
+
+            // B's logs sit at minutes 0..4 (oldest overall) so a global newest-10 trim would drop them.
+            for (var i = 0; i < 5; i++)
             {
                 var logId = Guid.CreateVersion7();
-                idsOldestToNewest.Add(logId);
-                db.ShockerControlLogs.Add(new ShockerControlLog
-                {
-                    Id = logId,
-                    ShockerId = shockerId,
-                    ControlledByUserId = userId,
-                    Intensity = 50,
-                    Duration = 1000,
-                    Type = ControlType.Shock,
-                    CustomName = null,
-                    CreatedAt = baseTime + TimeSpan.FromMinutes(i)
-                });
+                bIds.Add(logId);
+                db.ShockerControlLogs.Add(NewLog(logId, shockerB, ownerB, baseTime + TimeSpan.FromMinutes(i)));
+            }
+
+            // A's logs sit at minutes 100..114 (newest overall), the first 8 by C and the last 7 by D.
+            for (var i = 0; i < 15; i++)
+            {
+                var logId = Guid.CreateVersion7();
+                aOldestToNewest.Add(logId);
+                var controller = i < 8 ? controllerC : controllerD;
+                db.ShockerControlLogs.Add(NewLog(logId, shockerA, controller, baseTime + TimeSpan.FromMinutes(100 + i)));
             }
 
             await db.SaveChangesAsync();
@@ -82,22 +80,58 @@ public sealed class ControlLogRetentionTests
 
         var deleted = await db2.DeleteControlLogsBeyondPerUserLimitAsync(keep);
 
-        // The trim is global, but no other integration test writes shocker control logs, so this user's rows
-        // are the only ones in the table: exactly the oldest `seed - keep` are deleted and the newest `keep`
-        // remain. The count therefore equals this user's deletion.
-        await Assert.That(deleted).IsEqualTo(seed - keep);
+        // Only owner A is over the limit, so exactly its oldest 5 are removed. No other integration test
+        // writes control logs, so the global count equals A's deletion: 5. (Dropping PARTITION BY would
+        // delete 10; partitioning by controller instead of owner would delete 0.)
+        await Assert.That(deleted).IsEqualTo(5);
 
-        var survivingIds = await db2.ShockerControlLogs
-            .AsNoTracking()
-            .Where(l => l.ShockerId == shockerId)
-            .Select(l => l.Id)
-            .ToListAsync();
+        var survivingA = (await db2.ShockerControlLogs.AsNoTracking()
+            .Where(l => l.ShockerId == shockerA).Select(l => l.Id).ToListAsync()).ToHashSet();
+        var survivingB = await db2.ShockerControlLogs.AsNoTracking()
+            .Where(l => l.ShockerId == shockerB).Select(l => l.Id).ToListAsync();
 
-        var expectedSurviving = idsOldestToNewest.Skip(seed - keep).ToHashSet();
-        var expectedDeleted = idsOldestToNewest.Take(seed - keep).ToHashSet();
+        // A keeps its newest 10; its oldest 5 are gone.
+        await Assert.That(survivingA.SetEquals(aOldestToNewest.Skip(5).ToHashSet())).IsTrue();
+        await Assert.That(aOldestToNewest.Take(5).Any(survivingA.Contains)).IsFalse();
 
-        await Assert.That(survivingIds.Count).IsEqualTo(keep);
-        await Assert.That(survivingIds.ToHashSet().SetEquals(expectedSurviving)).IsTrue();
-        await Assert.That(survivingIds.Any(id => expectedDeleted.Contains(id))).IsFalse();
+        // B is under the limit, so every one of its (older) logs survives - a global trim would have deleted them.
+        await Assert.That(survivingB.Count).IsEqualTo(5);
     }
+
+    private static User NewUser(Guid id, string prefix) => new()
+    {
+        Id = id,
+        Name = $"{prefix}{id:N}"[..16],
+        Email = $"{prefix}-{id:N}@test.org",
+        SecurityStamp = Guid.CreateVersion7(),
+        CreatedAt = DateTime.UtcNow,
+        ActivatedAt = DateTime.UtcNow
+    };
+
+    private static void AddShocker(OpenShockContext db, Guid shockerId, Guid ownerId, ushort rfId)
+    {
+        var deviceId = Guid.CreateVersion7();
+        db.Devices.Add(new Device
+        {
+            Id = deviceId, OwnerId = ownerId, Name = "LogTrimHub",
+            Token = CryptoUtils.RandomAlphaNumericString(256), CreatedAt = DateTime.UtcNow
+        });
+        db.Shockers.Add(new Shocker
+        {
+            Id = shockerId, Name = "LogTrimShocker", RfId = rfId,
+            DeviceId = deviceId, Model = ShockerModelType.CaiXianlin
+        });
+    }
+
+    private static ShockerControlLog NewLog(Guid id, Guid shockerId, Guid controllerId, DateTime createdAt) => new()
+    {
+        Id = id,
+        ShockerId = shockerId,
+        ControlledByUserId = controllerId,
+        Intensity = 50,
+        Duration = 1000,
+        Type = ControlType.Shock,
+        CustomName = null,
+        CreatedAt = createdAt
+    };
 }

--- a/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
+++ b/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OpenShock.Common.Models;
+using OpenShock.Common.OpenShockDb;
+using OpenShock.Common.Utils;
+
+namespace OpenShock.Cron.IntegrationTests.Tests;
+
+/// <summary>
+/// End-to-end coverage for the Cron retention trim against real Postgres. Runs the cleanup job's *actual*
+/// statement (<see cref="ShockerControlLogQueries.DeleteControlLogsBeyondPerUserLimitAsync"/>, the single
+/// source of truth the job uses) over a seeded user -> device -> shocker -> logs graph, so the real table
+/// and column names, the shocker -> device -> owner join, the per-user window function, and the newest-first
+/// ordering are all exercised. A schema rename breaks this test rather than only the Cron host at runtime.
+/// </summary>
+public sealed class ControlLogRetentionTests
+{
+    [ClassDataSource<CronApplicationFactory>(Shared = SharedType.PerTestSession)]
+    public required CronApplicationFactory Factory { get; init; }
+
+    [Test]
+    public async Task DeleteControlLogsBeyondPerUserLimit_KeepsNewestPerUser_AndDeletesTheRest()
+    {
+        const int keep = 10;
+        const int seed = 15; // 5 over the limit
+
+        var userId = Guid.CreateVersion7();
+        var deviceId = Guid.CreateVersion7();
+        var shockerId = Guid.CreateVersion7();
+
+        // Seed `seed` logs with strictly increasing timestamps so newest-first ordering is unambiguous.
+        // Track the ids in age order; the newest `keep` should survive, the oldest `seed - keep` should go.
+        var idsOldestToNewest = new List<Guid>(seed);
+        var baseTime = DateTime.UtcNow - TimeSpan.FromDays(1);
+
+        await using (var db = await Factory.DbContextFactory.CreateDbContextAsync())
+        {
+            db.Users.Add(new User
+            {
+                Id = userId,
+                Name = $"logtrim{userId:N}"[..16],
+                Email = $"logtrim-{userId:N}@test.org",
+                SecurityStamp = Guid.CreateVersion7(),
+                CreatedAt = DateTime.UtcNow,
+                ActivatedAt = DateTime.UtcNow
+            });
+            db.Devices.Add(new Device
+            {
+                Id = deviceId, OwnerId = userId, Name = "LogTrimHub",
+                Token = CryptoUtils.RandomAlphaNumericString(256), CreatedAt = DateTime.UtcNow
+            });
+            db.Shockers.Add(new Shocker
+            {
+                Id = shockerId, Name = "LogTrimShocker", RfId = 1234,
+                DeviceId = deviceId, Model = ShockerModelType.CaiXianlin
+            });
+
+            for (var i = 0; i < seed; i++)
+            {
+                var logId = Guid.CreateVersion7();
+                idsOldestToNewest.Add(logId);
+                db.ShockerControlLogs.Add(new ShockerControlLog
+                {
+                    Id = logId,
+                    ShockerId = shockerId,
+                    ControlledByUserId = userId,
+                    Intensity = 50,
+                    Duration = 1000,
+                    Type = ControlType.Shock,
+                    CustomName = null,
+                    CreatedAt = baseTime + TimeSpan.FromMinutes(i)
+                });
+            }
+
+            await db.SaveChangesAsync();
+        }
+
+        // Resolve the pooled OpenShockContext exactly as the Cron cleanup job does (DI-injected) so this
+        // covers the same registration path that runs in production.
+        using var scope = Factory.Services.CreateScope();
+        var db2 = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
+
+        var deleted = await db2.DeleteControlLogsBeyondPerUserLimitAsync(keep);
+
+        // The trim is global, but no other integration test writes shocker control logs, so this user's rows
+        // are the only ones in the table: exactly the oldest `seed - keep` are deleted and the newest `keep`
+        // remain. The count therefore equals this user's deletion.
+        await Assert.That(deleted).IsEqualTo(seed - keep);
+
+        var survivingIds = await db2.ShockerControlLogs
+            .AsNoTracking()
+            .Where(l => l.ShockerId == shockerId)
+            .Select(l => l.Id)
+            .ToListAsync();
+
+        var expectedSurviving = idsOldestToNewest.Skip(seed - keep).ToHashSet();
+        var expectedDeleted = idsOldestToNewest.Take(seed - keep).ToHashSet();
+
+        await Assert.That(survivingIds.Count).IsEqualTo(keep);
+        await Assert.That(survivingIds.ToHashSet().SetEquals(expectedSurviving)).IsTrue();
+        await Assert.That(survivingIds.Any(id => expectedDeleted.Contains(id))).IsFalse();
+    }
+}

--- a/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
+++ b/Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs
@@ -77,7 +77,7 @@ public sealed class ControlLogRetentionTests
 
         // Resolve the pooled OpenShockContext exactly as the Cron cleanup job does (DI-injected) so this
         // covers the same registration path that runs in production.
-        using var scope = Factory.Services.CreateScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db2 = scope.ServiceProvider.GetRequiredService<OpenShockContext>();
 
         var deleted = await db2.DeleteControlLogsBeyondPerUserLimitAsync(keep);

--- a/Cron/Jobs/ClearOldShockerControlLogs.cs
+++ b/Cron/Jobs/ClearOldShockerControlLogs.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using OpenShock.Common.Constants;
+﻿using OpenShock.Common.Constants;
 using OpenShock.Common.OpenShockDb;
 using OpenShock.Cron.Attributes;
 
@@ -27,21 +26,8 @@ public sealed class ClearOldShockerControlLogs
 
     public async Task<int> Execute()
     {
-        var deletedUserLimits = await _db.Database.ExecuteSqlAsync(
-            $"""
-             WITH ranked_logs AS (
-               SELECT
-                 l.id,
-                 ROW_NUMBER() OVER (PARTITION BY d.owner_id ORDER BY l.created_at DESC) AS rn
-               FROM shocker_control_logs l
-               JOIN shockers s ON s.id = l.shocker_id
-               JOIN devices d ON d.id = s.device_id
-             )
-             DELETE FROM shocker_control_logs l
-             USING ranked_logs rl
-             WHERE l.id = rl.id
-               AND rl.rn > {HardLimits.MaxShockerControlLogsPerUser}
-             """);
+        var deletedUserLimits =
+            await _db.DeleteControlLogsBeyondPerUserLimitAsync(HardLimits.MaxShockerControlLogsPerUser);
 
         _logger.LogInformation("Deleted {deletedUserLimits} shocker control logs exceeding the per-user limit",
             deletedUserLimits);


### PR DESCRIPTION
## What

Mirrors the outbox claim-query extraction (#328) for the other piece of raw SQL in the Cron jobs — the `ClearOldShockerControlLogs` retention trim.

- Extract the inline CTE `DELETE` into `Common/OpenShockDb/ShockerControlLogQueries.cs` → `DeleteControlLogsBeyondPerUserLimitAsync(this OpenShockContext, int maxPerUser)`, a single source of truth the job and tests share. Parameterized by the per-user cap so tests can drive it with a small limit.
- `ClearOldShockerControlLogs` now calls that extension with `HardLimits.MaxShockerControlLogsPerUser`. No behavior change (identical SQL).
- Add `Cron.IntegrationTests/Tests/ControlLogRetentionTests.cs` (beside the other Cron delivery tests): seeds a user → device → shocker → logs graph and runs the **actual** statement against a Testcontainers Postgres — exercising the real table/column names, the `shocker → device → owner` join, the per-user window function, and newest-first ordering. Asserts the newest N survive and the older rows are deleted.

## Why

Same rationale as #328: inline raw SQL means a table/column rename only surfaces in the Cron host at runtime. Extracted and covered, a schema drift fails the test instead. The test lives in `Cron.IntegrationTests` because it exercises a Cron job's query, resolving the pooled `OpenShockContext` from the Cron host's own DI.

## Notes

- The trim is a global statement, but no other integration test writes shocker control logs, so the seeded user's rows are the only ones in the table — the deleted-count assertion is deterministic and the DELETE can't disturb other tests.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/API/pull/330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->