### PR TITLE
feat: emit DeviceUpdateType.Paired when a device consumes a pair code

### DIFF
--- a/API/Controller/Device/Pair.cs
+++ b/API/Controller/Device/Pair.cs
@@ -57,8 +57,15 @@ public sealed partial class DeviceController
         var device = await _db.Devices.Where(x => x.Id == pair.Id).Select(x => new { x.Token, x.OwnerId }).FirstOrDefaultAsync();
         if (device is null) throw new Exception("Device not found for pair code");
 
-        await _deviceUpdateService.UpdateDevice(device.OwnerId, pair.Id, DeviceUpdateType.Paired);
+try
+{
+    await _deviceUpdateService.UpdateDevice(device.OwnerId, pair.Id, DeviceUpdateType.Paired);
+}
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Failed to emit paired update for device {DeviceId}", pair.Id);
+}
 
-        return LegacyDataOk(device.Token);
+return LegacyDataOk(device.Token);
     }
 }

--- a/API/Controller/Device/Pair.cs
+++ b/API/Controller/Device/Pair.cs
@@ -57,15 +57,15 @@ public sealed partial class DeviceController
         var device = await _db.Devices.Where(x => x.Id == pair.Id).Select(x => new { x.Token, x.OwnerId }).FirstOrDefaultAsync();
         if (device is null) throw new Exception("Device not found for pair code");
 
-try
-{
-    await _deviceUpdateService.UpdateDevice(device.OwnerId, pair.Id, DeviceUpdateType.Paired);
-}
-catch (Exception ex)
-{
-    _logger.LogWarning(ex, "Failed to emit paired update for device {DeviceId}", pair.Id);
-}
+        try
+        {
+            await _deviceUpdateService.UpdateDevice(device.OwnerId, pair.Id, DeviceUpdateType.Paired);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to emit paired update for device {DeviceId}", pair.Id);
+        }
 
-return LegacyDataOk(device.Token);
+        return LegacyDataOk(device.Token);
     }
 }

--- a/API/Controller/Device/Pair.cs
+++ b/API/Controller/Device/Pair.cs
@@ -54,9 +54,11 @@ public sealed partial class DeviceController
         if (pair is null) return Problem(PairError.PairCodeNotFound);
         await devicePairs.DeleteAsync(pair);
 
-        var deviceToken = await _db.Devices.Where(x => x.Id == pair.Id).Select(x => x.Token).FirstOrDefaultAsync();
-        if (deviceToken is null) throw new Exception("Device not found for pair code");
+        var device = await _db.Devices.Where(x => x.Id == pair.Id).Select(x => new { x.Token, x.OwnerId }).FirstOrDefaultAsync();
+        if (device is null) throw new Exception("Device not found for pair code");
 
-        return LegacyDataOk(deviceToken);
+        await _deviceUpdateService.UpdateDevice(device.OwnerId, pair.Id, DeviceUpdateType.Paired);
+
+        return LegacyDataOk(device.Token);
     }
 }

--- a/API/Controller/Device/_ApiController.cs
+++ b/API/Controller/Device/_ApiController.cs
@@ -1,6 +1,7 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenShock.API.Services.DeviceUpdate;
 using OpenShock.Common;
 using OpenShock.Common.Authentication;
 using OpenShock.Common.OpenShockDb;
@@ -21,12 +22,14 @@ public sealed partial class DeviceController : OpenShockControllerBase
 {
     private readonly OpenShockContext _db;
     private readonly IRedisConnectionProvider _redis;
+    private readonly IDeviceUpdateService _deviceUpdateService;
     private readonly ILogger<DeviceController> _logger;
 
-    public DeviceController(OpenShockContext db, IRedisConnectionProvider redis, ILogger<DeviceController> logger)
+    public DeviceController(OpenShockContext db, IRedisConnectionProvider redis, IDeviceUpdateService deviceUpdateService, ILogger<DeviceController> logger)
     {
         _db = db;
         _redis = redis;
+        _deviceUpdateService = deviceUpdateService;
         _logger = logger;
     }
 }

--- a/Common/Models/DeviceUpdateType.cs
+++ b/Common/Models/DeviceUpdateType.cs
@@ -5,6 +5,6 @@ public enum DeviceUpdateType
     Created, // Whenever a new device is created
     Updated, // Whenever name or something else directly related to the device is updated
     ShockerUpdated, // Whenever a shocker is updated, name or limits for a person
-    Deleted // Whenever a device is deleted
-    
+    Deleted, // Whenever a device is deleted
+    Paired // Whenever a device consumes a pair code
 }


### PR DESCRIPTION
Adds a `Paired` value to the `DeviceUpdateType` enum and emits it when a device consumes a pair code, so clients are notified when a device pairs.

This is useful for closing the pairing dialog automatically after device has paired

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/API/pull/331">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->