### PR TITLE
feat: admin mail queue management and test-send endpoints

### DIFF
--- a/API/Controller/Admin/DTOs/EmailOutboxBulkRequest.cs
+++ b/API/Controller/Admin/DTOs/EmailOutboxBulkRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenShock.API.Controller.Admin.DTOs;
+
+/// <summary>
+/// A set of email outbox message ids to apply a bulk requeue/cancel/delete to.
+/// </summary>
+public sealed class EmailOutboxBulkRequest
+{
+    [Required]
+    [MaxLength(1000)]
+    public required Guid[] Ids { get; set; }
+}

--- a/API/Controller/Admin/DTOs/EmailOutboxBulkResultDto.cs
+++ b/API/Controller/Admin/DTOs/EmailOutboxBulkResultDto.cs
@@ -1,0 +1,11 @@
+namespace OpenShock.API.Controller.Admin.DTOs;
+
+/// <summary>
+/// Outcome of a bulk email outbox operation: how many ids were requested and how many rows were
+/// actually affected (rows that were missing or in an ineligible state are silently not counted).
+/// </summary>
+public sealed class EmailOutboxBulkResultDto
+{
+    public required int Requested { get; set; }
+    public required int Affected { get; set; }
+}

--- a/API/Controller/Admin/DTOs/EmailOutboxMessageDto.cs
+++ b/API/Controller/Admin/DTOs/EmailOutboxMessageDto.cs
@@ -1,0 +1,41 @@
+using OpenShock.Common.OpenShockDb;
+
+namespace OpenShock.API.Controller.Admin.DTOs;
+
+/// <summary>
+/// An <see cref="EmailOutboxMessage"/> as exposed to admins on the mail-queue page. Mirrors the row
+/// verbatim - the outbox stores no rendered body and no usable secret, so every field is safe to show.
+/// </summary>
+public sealed class EmailOutboxMessageDto
+{
+    public required Guid Id { get; set; }
+    public required EmailType Type { get; set; }
+    public required string Recipient { get; set; }
+    public required string? RecipientName { get; set; }
+    public required Dictionary<string, string> Payload { get; set; }
+    public required string? CoalesceKey { get; set; }
+    public required EmailStatus Status { get; set; }
+    public required int AttemptCount { get; set; }
+    public required DateTimeOffset NextAttemptAt { get; set; }
+    public required string? LastError { get; set; }
+    public required DateTimeOffset CreatedAt { get; set; }
+    public required DateTimeOffset? SentAt { get; set; }
+    public required DateTimeOffset? FailedAt { get; set; }
+
+    public static EmailOutboxMessageDto FromModel(EmailOutboxMessage m) => new()
+    {
+        Id = m.Id,
+        Type = m.Type,
+        Recipient = m.Recipient,
+        RecipientName = m.RecipientName,
+        Payload = m.Payload,
+        CoalesceKey = m.CoalesceKey,
+        Status = m.Status,
+        AttemptCount = m.AttemptCount,
+        NextAttemptAt = m.NextAttemptAt,
+        LastError = m.LastError,
+        CreatedAt = m.CreatedAt,
+        SentAt = m.SentAt,
+        FailedAt = m.FailedAt
+    };
+}

--- a/API/Controller/Admin/DTOs/EmailOutboxStatsDto.cs
+++ b/API/Controller/Admin/DTOs/EmailOutboxStatsDto.cs
@@ -1,0 +1,14 @@
+namespace OpenShock.API.Controller.Admin.DTOs;
+
+/// <summary>
+/// Count of email outbox rows in each delivery state, for the admin mail-queue overview tiles.
+/// </summary>
+public sealed class EmailOutboxStatsDto
+{
+    public required long Pending { get; set; }
+    public required long Sending { get; set; }
+    public required long Sent { get; set; }
+    public required long Failed { get; set; }
+    public required long Skipped { get; set; }
+    public required long Total { get; set; }
+}

--- a/API/Controller/Admin/DTOs/SendTestEmailDto.cs
+++ b/API/Controller/Admin/DTOs/SendTestEmailDto.cs
@@ -1,0 +1,20 @@
+using OpenShock.Common.OpenShockDb;
+
+namespace OpenShock.API.Controller.Admin.DTOs;
+
+/// <summary>
+/// Request to enqueue a preview/test email of a chosen type to a chosen address. The message is
+/// delivered by the Cron pipeline with placeholder data and a dummy link (no token, no request row).
+/// </summary>
+public sealed class SendTestEmailDto
+{
+    /// <summary>Which template to preview.</summary>
+    public required EmailType Type { get; set; }
+
+    /// <summary>Destination address for the test email.</summary>
+    [OpenShock.Common.DataAnnotations.EmailAddress(true)]
+    public required string Recipient { get; set; }
+
+    /// <summary>Optional display name for the recipient.</summary>
+    public string? RecipientName { get; set; }
+}

--- a/API/Controller/Admin/EmailOutboxBulk.cs
+++ b/API/Controller/Admin/EmailOutboxBulk.cs
@@ -1,0 +1,82 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenShock.API.Controller.Admin.DTOs;
+using OpenShock.Common.OpenShockDb;
+using OpenShock.Common.Services.RedisPubSub;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Requeues many email outbox messages at once. Each id is treated exactly like the single-message
+    /// requeue: only terminal (sent/failed/skipped) rows are affected; pending/sending rows and missing
+    /// ids are skipped. Returns how many rows were actually requeued.
+    /// </summary>
+    /// <response code="200">Bulk requeue applied</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpPost("email/outbox/bulk/requeue")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [ProducesResponseType<EmailOutboxBulkResultDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    public async Task<EmailOutboxBulkResultDto> BulkRequeueEmailOutbox([FromBody] EmailOutboxBulkRequest body, [FromServices] IRedisPubService redisPubService, CancellationToken ct)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        var affected = await _db.EmailOutbox
+            .Where(m => body.Ids.Contains(m.Id) && (m.Status == EmailStatus.Failed || m.Status == EmailStatus.Skipped || m.Status == EmailStatus.Sent))
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.Status, EmailStatus.Pending)
+                .SetProperty(m => m.NextAttemptAt, nowUtc)
+                .SetProperty(m => m.AttemptCount, 0)
+                .SetProperty(m => m.LastError, (string?)null)
+                .SetProperty(m => m.FailedAt, (DateTime?)null)
+                .SetProperty(m => m.SentAt, (DateTime?)null), ct);
+
+        if (affected > 0)
+        {
+            await redisPubService.SendEmailOutboxPending();
+        }
+
+        return new EmailOutboxBulkResultDto { Requested = body.Ids.Length, Affected = affected };
+    }
+
+    /// <summary>
+    /// Cancels many still-pending email outbox messages at once by marking them skipped. Rows that are
+    /// not pending (already sending or terminal) and missing ids are skipped. Returns how many rows were
+    /// actually cancelled.
+    /// </summary>
+    /// <response code="200">Bulk cancel applied</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpPost("email/outbox/bulk/cancel")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [ProducesResponseType<EmailOutboxBulkResultDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    public async Task<EmailOutboxBulkResultDto> BulkCancelEmailOutbox([FromBody] EmailOutboxBulkRequest body, CancellationToken ct)
+    {
+        var affected = await _db.EmailOutbox
+            .Where(m => body.Ids.Contains(m.Id) && m.Status == EmailStatus.Pending)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.Status, EmailStatus.Skipped)
+                .SetProperty(m => m.LastError, "Cancelled by admin"), ct);
+
+        return new EmailOutboxBulkResultDto { Requested = body.Ids.Length, Affected = affected };
+    }
+
+    /// <summary>
+    /// Permanently deletes many email outbox messages at once. Missing ids are skipped. Returns how many
+    /// rows were actually deleted.
+    /// </summary>
+    /// <response code="200">Bulk delete applied</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpPost("email/outbox/bulk/delete")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [ProducesResponseType<EmailOutboxBulkResultDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    public async Task<EmailOutboxBulkResultDto> BulkDeleteEmailOutbox([FromBody] EmailOutboxBulkRequest body, CancellationToken ct)
+    {
+        var affected = await _db.EmailOutbox
+            .Where(m => body.Ids.Contains(m.Id))
+            .ExecuteDeleteAsync(ct);
+
+        return new EmailOutboxBulkResultDto { Requested = body.Ids.Length, Affected = affected };
+    }
+}

--- a/API/Controller/Admin/EmailOutboxCancel.cs
+++ b/API/Controller/Admin/EmailOutboxCancel.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenShock.Common.OpenShockDb;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Cancels a still-pending email outbox message by marking it skipped, so it is never sent. Only
+    /// pending messages can be cancelled; a message already being sent or in a terminal state cannot.
+    /// </summary>
+    /// <response code="200">Cancelled</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="404">No such message</response>
+    /// <response code="409">Message is not pending</response>
+    [HttpPost("email/outbox/{id}/cancel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CancelEmailOutbox([FromRoute] Guid id, CancellationToken ct)
+    {
+        var updated = await _db.EmailOutbox
+            .Where(m => m.Id == id && m.Status == EmailStatus.Pending)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.Status, EmailStatus.Skipped)
+                .SetProperty(m => m.LastError, "Cancelled by admin"), ct);
+
+        if (updated == 0)
+        {
+            var exists = await _db.EmailOutbox.AnyAsync(m => m.Id == id, ct);
+            return exists ? Conflict() : NotFound();
+        }
+
+        return Ok();
+    }
+}

--- a/API/Controller/Admin/EmailOutboxDelete.cs
+++ b/API/Controller/Admin/EmailOutboxDelete.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Permanently deletes an email outbox message. If the delivery consumer is mid-send it simply finds
+    /// the row gone and does nothing, so a delete never corrupts an in-flight send.
+    /// </summary>
+    /// <response code="200">Deleted</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="404">No such message</response>
+    [HttpDelete("email/outbox/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteEmailOutbox([FromRoute] Guid id, CancellationToken ct)
+    {
+        var nDeleted = await _db.EmailOutbox.Where(m => m.Id == id).ExecuteDeleteAsync(ct);
+
+        return nDeleted == 0 ? NotFound() : Ok();
+    }
+}

--- a/API/Controller/Admin/EmailOutboxList.cs
+++ b/API/Controller/Admin/EmailOutboxList.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenShock.API.Controller.Admin.DTOs;
+using OpenShock.Common.Errors;
+using OpenShock.Common.Extensions;
+using OpenShock.Common.Models;
+using OpenShock.Common.OpenShockDb;
+using OpenShock.Common.Query;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using Z.EntityFramework.Plus;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Lists email outbox messages, paginated. Supports the same OData-style
+    /// <c>$filter</c>/<c>$orderby</c> as the users listing (e.g. <c>status eq 'failed'</c>,
+    /// <c>recipient ilike '%@example.com'</c>). Defaults to newest first.
+    /// </summary>
+    /// <response code="200">Paginated email outbox messages</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpGet("email/outbox")]
+    [ProducesResponseType<Paginated<EmailOutboxMessageDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    public async Task<IActionResult> GetEmailOutbox(
+        [FromQuery(Name = "$filter")] string filterQuery = "",
+        [FromQuery(Name = "$orderby")] string orderbyQuery = "",
+        [FromQuery(Name = "$offset")][Range(0, int.MaxValue)] int offset = 0,
+        [FromQuery(Name = "$limit")][Range(1, 1000)] int limit = 100
+        )
+    {
+        var query = _db.EmailOutbox.AsNoTracking();
+
+        try
+        {
+            if (!string.IsNullOrEmpty(filterQuery))
+            {
+                query = query.ApplyFilter(filterQuery);
+            }
+
+            if (!string.IsNullOrEmpty(orderbyQuery))
+            {
+                query = query.ApplyOrderBy(orderbyQuery);
+            }
+            else
+            {
+                query = query.OrderByDescending(m => m.CreatedAt);
+            }
+        }
+        catch (QueryStringTokenizerException e)
+        {
+            return Problem(ExpressionError.QueryStringInvalidError(e.Message));
+        }
+        catch (DBExpressionBuilderException e)
+        {
+            return Problem(ExpressionError.ExpressionExceptionError(e.Message));
+        }
+        catch (FormatException e)
+        {
+            return Problem(ExpressionError.ExpressionExceptionError(e.Message));
+        }
+
+        var deferredCount = query.DeferredLongCount().FutureValue();
+
+        if (offset != 0)
+        {
+            query = query.Skip(offset);
+        }
+
+        var deferredMessages = query.Take(limit).Future();
+
+        return Ok(new Paginated<EmailOutboxMessageDto>
+        {
+            Data = (await deferredMessages.ToArrayAsync()).Select(EmailOutboxMessageDto.FromModel).ToArray(),
+            Offset = offset,
+            Limit = limit,
+            Total = await deferredCount.ValueAsync(),
+        });
+    }
+}

--- a/API/Controller/Admin/EmailOutboxRequeue.cs
+++ b/API/Controller/Admin/EmailOutboxRequeue.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenShock.Common.OpenShockDb;
+using OpenShock.Common.Services.RedisPubSub;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Requeues a terminal (sent/failed/skipped) email outbox message: resets it to pending, due now,
+    /// with a fresh attempt budget, and nudges the delivery consumer to send it immediately.
+    /// </summary>
+    /// <response code="200">Requeued</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="404">No such message</response>
+    /// <response code="409">Message is pending or currently being sent</response>
+    [HttpPost("email/outbox/{id}/requeue")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> RequeueEmailOutbox([FromRoute] Guid id, [FromServices] IRedisPubService redisPubService, CancellationToken ct)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        // Guard on a terminal status so a concurrent Cron send (Sending) or an already-queued row
+        // (Pending) is left alone - the WHERE simply matches nothing rather than racing the send.
+        var updated = await _db.EmailOutbox
+            .Where(m => m.Id == id && (m.Status == EmailStatus.Failed || m.Status == EmailStatus.Skipped || m.Status == EmailStatus.Sent))
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.Status, EmailStatus.Pending)
+                .SetProperty(m => m.NextAttemptAt, nowUtc)
+                .SetProperty(m => m.AttemptCount, 0)
+                .SetProperty(m => m.LastError, (string?)null)
+                .SetProperty(m => m.FailedAt, (DateTime?)null)
+                .SetProperty(m => m.SentAt, (DateTime?)null), ct);
+
+        if (updated == 0)
+        {
+            var exists = await _db.EmailOutbox.AnyAsync(m => m.Id == id, ct);
+            return exists ? Conflict() : NotFound();
+        }
+
+        await redisPubService.SendEmailOutboxPending();
+
+        return Ok();
+    }
+}

--- a/API/Controller/Admin/EmailOutboxStats.cs
+++ b/API/Controller/Admin/EmailOutboxStats.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenShock.API.Controller.Admin.DTOs;
+using OpenShock.Common.OpenShockDb;
+using System.Net.Mime;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Returns the number of email outbox messages in each delivery state.
+    /// </summary>
+    /// <response code="200">Per-status counts</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpGet("email/outbox/stats")]
+    [ProducesResponseType<EmailOutboxStatsDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    public async Task<EmailOutboxStatsDto> GetEmailOutboxStats()
+    {
+        var counts = await _db.EmailOutbox
+            .AsNoTracking()
+            .GroupBy(m => m.Status)
+            .Select(g => new { Status = g.Key, Count = g.LongCount() })
+            .ToDictionaryAsync(x => x.Status, x => x.Count);
+
+        long Count(EmailStatus status) => counts.GetValueOrDefault(status);
+
+        return new EmailOutboxStatsDto
+        {
+            Pending = Count(EmailStatus.Pending),
+            Sending = Count(EmailStatus.Sending),
+            Sent = Count(EmailStatus.Sent),
+            Failed = Count(EmailStatus.Failed),
+            Skipped = Count(EmailStatus.Skipped),
+            Total = counts.Values.Sum()
+        };
+    }
+}

--- a/API/Controller/Admin/EmailOutboxTestSend.cs
+++ b/API/Controller/Admin/EmailOutboxTestSend.cs
@@ -1,0 +1,36 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using OpenShock.API.Controller.Admin.DTOs;
+using OpenShock.Common.OpenShockDb;
+using OpenShock.Common.Services.RedisPubSub;
+
+namespace OpenShock.API.Controller.Admin;
+
+public sealed partial class AdminController
+{
+    /// <summary>
+    /// Enqueues a preview/test email of the chosen type to the chosen address. It flows through the
+    /// normal durable delivery pipeline - visible in the outbox listing - but is rendered with
+    /// placeholder data and a dummy link, so it touches no request row and mints no token.
+    /// </summary>
+    /// <response code="200">Test email enqueued</response>
+    /// <response code="400">Invalid recipient address</response>
+    /// <response code="401">Unauthorized</response>
+    [HttpPost("email/test")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [ProducesResponseType<EmailOutboxMessageDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> SendTestEmail([FromBody] SendTestEmailDto body, [FromServices] IRedisPubService redisPubService, CancellationToken ct)
+    {
+        // CreatedAt / NextAttemptAt / AttemptCount are filled by their DB defaults (see the context
+        // mapping) and read back after insert, so the returned DTO carries the real values.
+        var message = EmailOutboxMessage.ForPreview(body.Type, body.Recipient, body.RecipientName);
+
+        _db.EmailOutbox.Add(message);
+        await _db.SaveChangesAsync(ct);
+
+        await redisPubService.SendEmailOutboxPending();
+
+        return Ok(EmailOutboxMessageDto.FromModel(message));
+    }
+}

--- a/Common.Tests/OpenShockDb/EmailOutboxMessageTests.cs
+++ b/Common.Tests/OpenShockDb/EmailOutboxMessageTests.cs
@@ -35,4 +35,17 @@ public class EmailOutboxMessageTests
         await Assert.That(message.RecipientName).IsNull();
         await Assert.That(message.Payload[EmailOutboxPayloadKeys.NewEmail]).IsEqualTo("new@example.com");
     }
+
+    [Test]
+    public async Task ForPreview_FlagsPreviewAndNeverCoalesces()
+    {
+        var message = EmailOutboxMessage.ForPreview(EmailType.PasswordReset, "admin@example.com", "Admin");
+
+        await Assert.That(message.Status).IsEqualTo(EmailStatus.Pending);
+        await Assert.That(message.Type).IsEqualTo(EmailType.PasswordReset);
+        await Assert.That(message.Recipient).IsEqualTo("admin@example.com");
+        // Never coalesced, so every test send is delivered on its own.
+        await Assert.That(message.CoalesceKey).IsNull();
+        await Assert.That(message.Payload[EmailOutboxPayloadKeys.Preview]).IsEqualTo("true");
+    }
 }

--- a/Common/OpenShockDb/Keys/EmailOutboxPayloadKeys.cs
+++ b/Common/OpenShockDb/Keys/EmailOutboxPayloadKeys.cs
@@ -21,4 +21,12 @@ public static class EmailOutboxPayloadKeys
 
     /// <summary>The newly requested address. Used by <see cref="EmailType.EmailChangeNotice"/>.</summary>
     public const string NewEmail = "newEmail";
+
+    /// <summary>
+    /// Present (value <c>"true"</c>) on a preview/test message enqueued by an admin. It marks the row so
+    /// the delivery dispatcher renders the chosen <see cref="EmailType"/>'s template with placeholder
+    /// data and a dummy link instead of looking up a real request row or minting a token. Never set on
+    /// a real transactional email.
+    /// </summary>
+    public const string Preview = "preview";
 }

--- a/Common/OpenShockDb/Models/EmailOutboxMessage.cs
+++ b/Common/OpenShockDb/Models/EmailOutboxMessage.cs
@@ -156,4 +156,15 @@ public sealed class EmailOutboxMessage
     public static EmailOutboxMessage ForEmailChangeNotice(string newEmail, string recipient, string? recipientName) =>
         Create(EmailType.EmailChangeNotice, recipient, recipientName,
             new Dictionary<string, string> { [EmailOutboxPayloadKeys.NewEmail] = newEmail });
+
+    /// <summary>
+    /// A preview/test email of the given <paramref name="type"/>, enqueued by an admin to verify the
+    /// provider end to end. Carries only the <see cref="EmailOutboxPayloadKeys.Preview"/> flag: the
+    /// delivery dispatcher renders that type's template with placeholder data and a dummy link rather
+    /// than touching any request row or minting a token. Always delivered (no coalesce key), so every
+    /// test send goes out on its own.
+    /// </summary>
+    public static EmailOutboxMessage ForPreview(EmailType type, string recipient, string? recipientName) =>
+        Create(type, recipient, recipientName,
+            new Dictionary<string, string> { [EmailOutboxPayloadKeys.Preview] = "true" });
 }

--- a/Cron/Services/Email/Outbox/EmailOutboxDispatcher.cs
+++ b/Cron/Services/Email/Outbox/EmailOutboxDispatcher.cs
@@ -28,6 +28,14 @@ public sealed class EmailOutboxDispatcher : IEmailOutboxDispatcher
     {
         try
         {
+            // Admin preview/test send: render the chosen type's template with placeholder data and a
+            // dummy link, bypassing the request-row lookup and token minting entirely. Kept in front of
+            // the normal switch so a preview can never touch or mutate a real request row.
+            if (message.Payload.ContainsKey(EmailOutboxPayloadKeys.Preview))
+            {
+                return await SendPreview(message, cancellationToken);
+            }
+
             return message.Type switch
             {
                 EmailType.AccountActivation => await SendAccountActivation(message, db, cancellationToken),
@@ -108,6 +116,27 @@ public sealed class EmailOutboxDispatcher : IEmailOutboxDispatcher
 
         // No token: this is a pure informational notice to the previous address.
         return FromSend(await _emailService.EmailChangeNotice(ToContact(message), newEmail, ct));
+    }
+
+    /// <summary>
+    /// Delivers an admin preview/test message (see <see cref="EmailOutboxMessage.ForPreview"/>): renders
+    /// the chosen type's real template so an operator can confirm the provider works and see the actual
+    /// layout, but with a placeholder link/address instead of a real, working secret. Touches no request
+    /// row and mints no token, so it is safe to send to any address.
+    /// </summary>
+    private async Task<EmailDispatchResult> SendPreview(EmailOutboxMessage message, CancellationToken ct)
+    {
+        var to = ToContact(message);
+        var link = new Uri(_frontendOptions.BaseUrl, "/preview/example-link");
+
+        return message.Type switch
+        {
+            EmailType.AccountActivation => FromSend(await _emailService.ActivateAccount(to, link, ct)),
+            EmailType.PasswordReset => FromSend(await _emailService.PasswordReset(to, link, ct)),
+            EmailType.EmailVerification => FromSend(await _emailService.VerifyEmail(to, link, ct)),
+            EmailType.EmailChangeNotice => FromSend(await _emailService.EmailChangeNotice(to, "new-address@example.com", ct)),
+            _ => EmailDispatchResult.Permanent($"Unknown email type {message.Type}")
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Adds admin API endpoints to inspect and manage the email outbox (the durable mail queue) and to send preview/test mail, plus the supporting Common/Cron changes.

### Common
- `EmailOutboxPayloadKeys.Preview` flag and `EmailOutboxMessage.ForPreview(type, recipient, name)` factory — always-delivered (no coalescing).

### Cron
- `EmailOutboxDispatcher` renders a flagged **preview** message with the chosen template and a dummy link, touching no request row and minting no token — so a test send is safe to any address and flows through the normal durable pipeline.

### API — `Admin` role, under `/admin/email`
- `GET  /email/outbox` — paginated list (`$filter`/`$orderby`/`$offset`/`$limit`, same convention as the users list; enum filtering like `status eq 'Failed'`)
- `GET  /email/outbox/stats` — per-status counts
- `POST /email/outbox/{id}/requeue` · `/cancel` · `DELETE /email/outbox/{id}`
- `POST /email/test` — enqueues a preview send
- `POST /email/outbox/bulk/requeue` · `/bulk/cancel` · `/bulk/delete` — bulk variants (return requested/affected counts)

Requeue/cancel guard on status via `ExecuteUpdate`, sidestepping the `AttemptCount` concurrency token and racing safely against in-flight Cron sends (missing → 404, ineligible → 409).

## Notes
- **No DB migration** — reuses the existing `email_outbox` table; preview is an existing `EmailType` + a payload flag.

## Testing
- Full solution builds clean.
- `Common.Tests` (incl. a new `ForPreview` test) and `Cron.Tests` pass.
- End-to-end run + integration tests not exercised in this environment (no reachable Postgres/Redis); worth a manual E2E: send test → row appears `Pending` → Cron flips to `Sent`; force-fail → requeue.

The admin frontend page that drives these endpoints is in a separate PR on the frontend repo.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/API/pull/335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->