### PR TITLE
(vibe-coded, pls not pull without read, use as concept) (fix) (self) keepalive ping system on server for prevent hub to offline

### DIFF
--- a/Common/OpenShockApplication.cs
+++ b/Common/OpenShockApplication.cs
@@ -46,6 +46,10 @@ public static class OpenShockApplication
         builder.WebHost.ConfigureKestrel(serverOptions =>
         {
             serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMilliseconds(3000);
+            // Hub / live-control sockets are mostly idle on the receive side between
+            // pongs. The default 240 B/s body rate would abort them.
+            serverOptions.Limits.MinRequestBodyDataRate = null;
+            serverOptions.Limits.MinResponseDataRate = null;
         });
 
         builder.Host.UseSerilog((context, _, config) => config.ReadFrom.Configuration(context.Configuration));

--- a/Common/OpenShockMiddlewareHelper.cs
+++ b/Common/OpenShockMiddlewareHelper.cs
@@ -99,7 +99,9 @@ public static class OpenShockMiddlewareHelper
         
         app.UseWebSockets(new WebSocketOptions
         {
-            KeepAliveInterval = TimeSpan.FromMinutes(1)
+            // RFC 6455 ping frames. Firmware 1.6.0-rc.1 ignores these for its 90s
+            // application timer, but they keep NAT / reverse-proxy idle timers alive.
+            KeepAliveInterval = TimeSpan.FromSeconds(15)
         });
         app.UseRouting();
         app.UseAuthentication();

--- a/Common/OpenShockServiceHelper.cs
+++ b/Common/OpenShockServiceHelper.cs
@@ -362,13 +362,22 @@ public static class OpenShockServiceHelper
     public static IServiceCollection AddOpenShockSignalR(this IServiceCollection services,
         ConfigurationOptions redisConfig)
     {
-        services.AddSignalR()
-            .AddOpenShockStackExchangeRedis(options => { options.Configuration = redisConfig; })
-            .AddJsonProtocol(options =>
-            {
-                options.PayloadSerializerOptions.PropertyNameCaseInsensitive = true;
-                options.PayloadSerializerOptions.Converters.Add(new SemVersionJsonConverter());
-            });
+        services.AddSignalR(options =>
+        {
+            // Browser UserHub only. Hub firmware uses a raw WebSocket at /2/ws/hub
+            // and application-level FlatBuffer Ping — these options do not apply there.
+            options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+            options.ClientTimeoutInterval = TimeSpan.FromSeconds(120);
+        })
+        .AddOpenShockStackExchangeRedis(options => 
+        { 
+            options.Configuration = redisConfig; 
+        })
+        .AddJsonProtocol(options =>
+        {
+            options.PayloadSerializerOptions.PropertyNameCaseInsensitive = true;
+            options.PayloadSerializerOptions.Converters.Add(new SemVersionJsonConverter());
+        });
 
         return services;
     }

--- a/LiveControlGateway/Controllers/HubV2Controller.cs
+++ b/LiveControlGateway/Controllers/HubV2Controller.cs
@@ -16,7 +16,8 @@ using OpenShock.Serialization.Types;
 using Serilog;
 
 namespace OpenShock.LiveControlGateway.Controllers;
-//TODO: Implement new keep alive ping pong mechanism
+// Hub keep-alive is application-level FlatBuffer Ping/Pong (see SendInitialData),
+// not RFC 6455 ping frames and not SignalR.
 /// <summary>
 /// Communication with the hubs aka ESP-32 microcontrollers
 /// </summary>
@@ -49,7 +50,18 @@ public sealed class HubV2Controller : HubControllerBase<HubToGatewayMessage, Gat
         : base(HubToGatewayMessage.Serializer, GatewayToHubMessage.Serializer, hubLifetimeManager, serviceProvider, options, logger)
     {
         _userHubContext = userHubContext;
-        _pingTimer = new Timer(PingTimerElapsed, null, Duration.DevicePingInitialDelay, Duration.DevicePingPeriod);
+        // Do not start until the socket is accepted — see SendInitialData.
+        _pingTimer = new Timer(PingTimerElapsed, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    /// <inheritdoc />
+    protected override Task SendInitialData()
+    {
+        // Firmware 1.6.0-rc.1 starts a 90s timer on the first application Ping and
+        // disconnects if another Ping does not arrive in time. RFC 6455 ping frames
+        // do not reset that timer. Kick the first Ping as soon as the socket is up.
+        _pingTimer.Change(TimeSpan.Zero, Duration.DevicePingPeriod);
+        return Task.CompletedTask;
     }
 
     private async void PingTimerElapsed(object? state)
@@ -57,6 +69,7 @@ public sealed class HubV2Controller : HubControllerBase<HubToGatewayMessage, Gat
         try
         {
             _pingTimestamp = Stopwatch.GetTimestamp();
+            Logger.LogDebug("Sending ping to hub [{HubId}]", CurrentHubId);
             await QueueMessage(new GatewayToHubMessage
             {
                 Payload = new GatewayToHubMessagePayload(new Ping


### PR DESCRIPTION
I try two different esp modules, 1.5, 1.6 fw versions, my device goes offline after 1.5 - 2.0 mintes without actions
With in 2 minutes, shock work correct, but if no acticity, goes offline

this fix help me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability for idle live-control and hub connections by preventing premature timeouts.
  * Added more frequent WebSocket and SignalR keep-alive messages to help maintain connections through NAT and reverse proxies.
  * Improved hub keep-alive timing, including application-level ping handling after initial hub data is sent.
  * Added debug logging for outgoing hub ping messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->